### PR TITLE
session: allow to borrow the stream mutably

### DIFF
--- a/src/session/async_session.rs
+++ b/src/session/async_session.rs
@@ -38,6 +38,11 @@ impl<P, S> Session<P, S> {
         self.stream.set_expect_timeout(expect_timeout);
     }
 
+    /// Borrow mutably the session's stream.
+    pub fn stream_mut(&mut self) -> &mut Stream<S> {
+        &mut self.stream
+    }
+
     pub(crate) fn swap_stream<F: FnOnce(S) -> R, R>(
         mut self,
         new_stream: F,
@@ -221,9 +226,9 @@ impl<P: Unpin, S: AsyncRead + Unpin> AsyncBufRead for Session<P, S> {
 }
 
 /// Session represents a spawned process and its streams.
-/// It controlls process and communication with it.
+/// It controls process and communication with it.
 #[derive(Debug)]
-struct Stream<S> {
+pub struct Stream<S> {
     stream: BufferedStream<S>,
     expect_timeout: Option<Duration>,
 }

--- a/src/session/sync_session.rs
+++ b/src/session/sync_session.rs
@@ -55,6 +55,11 @@ impl<P, S> Session<P, S> {
     pub fn set_expect_timeout(&mut self, expect_timeout: Option<Duration>) {
         self.expect_timeout = expect_timeout;
     }
+
+    /// Borrow mutably the session's stream.
+    pub fn stream_mut(&mut self) -> &mut TryStream<S> {
+        &mut self.stream
+    }
 }
 
 impl<P, S: Read + NonBlocking> Session<P, S> {
@@ -349,8 +354,10 @@ impl<P, S> DerefMut for Session<P, S> {
     }
 }
 
+/// Session represents a spawned process and its streams.
+/// It controls process and communication with it.
 #[derive(Debug)]
-struct TryStream<S> {
+pub struct TryStream<S> {
     stream: ControlledReader<S>,
 }
 
@@ -416,7 +423,10 @@ impl<R: Read + NonBlocking> TryStream<R> {
         }
     }
 
-    fn read_available(&mut self) -> std::io::Result<bool> {
+    /// Try to read in a non-blocking mode. Returns true on EOF.
+    ///
+    /// It raises io::ErrorKind::WouldBlock if there's nothing to read.
+    pub fn read_available(&mut self) -> std::io::Result<bool> {
         self.stream.flush_in_buffer();
 
         let mut buf = [0; 248];


### PR DESCRIPTION
related to #35 - we'd like to be able to get access to the session's stream - we're using it to put a process to a background with <https://github.com/anoma/anoma/blob/c17f4f634b14ee2f202ec51c3f9d4eb1a7f996a1/tests/src/e2e/setup.rs#L468> - we found unlike in rexpect, when we run multiple sessions at once and the commands that they run interact with each other in some way, if some session's output is not being processed it gets blocked on it