### PR TITLE
doc sync session

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -280,7 +280,6 @@ impl<P, S: Read + NonBlocking + Write> ReplSession<P, S> {
     /// Sends line to repl (and flush the output).
     ///
     /// If echo_on=true wait for the input to appear.
-    #[cfg(not(feature = "async"))]
     pub fn send_line<SS: AsRef<str>>(&mut self, line: SS) -> Result<(), Error> {
         self.session.send_line(line.as_ref())?;
         if self.is_echo_on {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -17,7 +17,7 @@
 
 #[cfg(feature = "async")]
 pub mod async_session;
-#[cfg(not(feature = "async"))]
+#[cfg(any(not(feature = "async"), doc))]
 pub mod sync_session;
 
 use std::io::{Read, Write};


### PR DESCRIPTION
hi again, just a small fix-up to get `sync_session` to show up in docs. There are bunch of other things with `#[cfg(not(feature = "async"))]` that get excluded, but because they share the same name in `#[cfg(feature = "async")]`, enabling those doesn't work together :/