### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/session/sync_session.rs
+++ b/src/session/sync_session.rs
@@ -475,10 +475,7 @@ impl<R: Read + NonBlocking> TryStream<R> {
     fn try_read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.stream.get_mut().set_non_blocking()?;
 
-        let result = match self.stream.inner.read(buf) {
-            Ok(n) => Ok(n),
-            Err(err) => Err(err),
-        };
+        let result = self.stream.inner.read(buf);
 
         // As file is DUPed changes in one descriptor affects all ones
         // so we need to make blocking file after we finished.
@@ -531,10 +528,7 @@ impl<R: Read + NonBlocking> TryStream<R> {
     fn try_read_inner(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.stream.get_mut().set_non_blocking()?;
 
-        let result = match self.stream.get_mut().read(buf) {
-            Ok(n) => Ok(n),
-            Err(err) => Err(err),
-        };
+        let result = self.stream.get_mut().read(buf);
 
         // As file is DUPed changes in one descriptor affects all ones
         // so we need to make blocking file after we finished.

--- a/src/stream/stdin.rs
+++ b/src/stream/stdin.rs
@@ -109,10 +109,7 @@ impl Read for Stdin {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         crate::process::unix::_make_non_blocking(self.stdin.as_raw_fd(), true)?;
 
-        let result = match self.stdin.read(buf) {
-            Ok(n) => Ok(n),
-            Err(err) => Err(err),
-        };
+        let result = self.stdin.read(buf);
 
         crate::process::unix::_make_non_blocking(self.stdin.as_raw_fd(), false)?;
 


### PR DESCRIPTION
Fixes a clippy warning that was added in Rust v1.61