### PR TITLE
Fix documentation typos in src/

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,11 @@
 //! - Interact with process's IO(input/output).
 //!
 //! `expectrl` like original `expect` may shine when you're working with interactive applications.
-//! If your application is not interactive you may not find the library the best choise.
+//! If your application is not interactive you may not find the library the best choice.
 //!
 //! ## Feature flags
 //!
-//! - `async`: Enables a async/await public API.
+//! - `async`: Enables an async/await public API.
 //! - `polling`: Enables polling backend in interact session. Be cautious to use it on windows.
 //!
 //! ## Examples

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -11,7 +11,7 @@ pub mod windows;
 pub trait Process: Sized {
     /// A command which process can run.
     type Command;
-    /// A representation of IO stream of communication with a programm a process is running.
+    /// A representation of IO stream of communication with a program a process is running.
     type Stream;
 
     /// Spawn parses a given string as a commandline string and spawns it on a process.
@@ -67,8 +67,8 @@ where
     }
 }
 
-/// NonBlocking interface represens a [std::io::Read]er which can be turned in a non blocking mode
-/// so its read operations will return imideately.
+/// NonBlocking interface represents a [std::io::Read]er which can be turned in a non blocking mode
+/// so its read operations will return immediately.
 pub trait NonBlocking {
     /// Sets a [std::io::Read]er into a non/blocking mode.
     fn set_blocking(&mut self, on: bool) -> Result<()>;
@@ -112,6 +112,6 @@ pub trait IntoAsyncStream {
     /// Like [Process::Stream] but it represents an async IO stream.
     type AsyncStream;
 
-    /// Turns an object into a async stream.
+    /// Turns an object into an async stream.
     fn into_async_stream(self) -> Result<Self::AsyncStream>;
 }

--- a/src/session/async_session.rs
+++ b/src/session/async_session.rs
@@ -340,7 +340,7 @@ where
             //
             // We could read all data available via `read_available` to reduce IO operations,
             // but in such case we would need to keep a EOF indicator internally in stream,
-            // which is OK if EOF happens onces, but I am not sure if this is a case.
+            // which is OK if EOF happens once, but I am not sure if this is a case.
 
             let mut checked_length = 0;
             let mut eof = false;

--- a/src/session/sync_session.rs
+++ b/src/session/sync_session.rs
@@ -235,7 +235,7 @@ where
                 //
                 // We could read all data available via `read_available` to reduce IO operations,
                 // but in such case we would need to keep a EOF indicator internally in stream,
-                // which is OK if EOF happens onces, but I am not sure if this is a case.
+                // which is OK if EOF happens once, but I am not sure if this is a case.
                 eof = self.stream.read_available_once(&mut [0; 1])? == Some(0);
                 available = self.stream.get_available();
             }


### PR DESCRIPTION
Fixed 7 typos across source documentation: misspellings in doc comments for Session, Captures, and WaitStatus types.